### PR TITLE
Fix three code bugs

### DIFF
--- a/backend/src/controllers/comment.controller.js
+++ b/backend/src/controllers/comment.controller.js
@@ -93,14 +93,14 @@ export const likeComment = asyncHandler(async (req, res) => {
     return res.status(404).json({ error: "User or comment not found" })
   }
 
-  const isLiked = comment.likes.includes(user._id)
+  const isLiked = comment.likes.some((id) => id.toString() === user._id.toString())
 
   if (isLiked) {
     // Unlike
     await Comment.findByIdAndUpdate(commentId, { $pull: { likes: user._id } })
   } else {
-    // Like
-    await Comment.findByIdAndUpdate(commentId, { $push: { likes: user._id } })
+    // Like (avoid duplicates)
+    await Comment.findByIdAndUpdate(commentId, { $addToSet: { likes: user._id } })
   }
 
   const updatedComment = await Comment.findById(commentId).populate(

--- a/backend/src/controllers/user.controller.js
+++ b/backend/src/controllers/user.controller.js
@@ -81,7 +81,8 @@ export const getAllUsers = async (req, res) => {
  */
 export const getUserById = async (req, res) => {
 	try {
-		const user = await User.findOne({ clerkId: req.params.userId });
+		const { username } = req.params;
+		const user = await User.findOne({ username });
 		if (!user) {
 			return res.status(404).json({ message: "User not found" });
 		}

--- a/backend/src/middleware/auth.middleware.js
+++ b/backend/src/middleware/auth.middleware.js
@@ -1,6 +1,13 @@
-export const protectRoute = async (req, res, next) => {
-  if (!req.auth().isAuthenticated) {
-    return res.status(401).json({ message: "Unauthorized - you must be logged in" });
+import { getAuth } from "@clerk/express";
+
+export const protectRoute = (req, res, next) => {
+  try {
+    const { userId } = getAuth(req);
+    if (!userId) {
+      return res.status(401).json({ message: "Unauthorized - you must be logged in" });
+    }
+    return next();
+  } catch (err) {
+    return res.status(401).json({ message: "Unauthorized - invalid auth context" });
   }
-  next();
 };


### PR DESCRIPTION
Fixes three bugs: broken auth guard, incorrect user profile lookup, and duplicate comment likes.

- **Broken Auth Guard:** The `protectRoute` middleware incorrectly used `req.auth().isAuthenticated`, which could lead to runtime errors or incorrect authorization. This is fixed by using Clerk's `getAuth(req)` and checking `userId`, with a try/catch for robustness.
- **Incorrect User Profile Lookup:** The `getUserById` controller was fetching by `clerkId: req.params.userId` while the route `GET /api/users/profile/:username` passed a `username` parameter, causing 404s. The controller now correctly queries by `username`.
- **Duplicate Comment Likes:** The comment like/unlike logic used `comment.likes.includes(user._id)` which is unreliable for Mongoose ObjectIds, and `$push` could create duplicate likes. This is fixed by comparing ObjectIds using `toString()` and using `$addToSet` to prevent duplicates.

---
<a href="https://cursor.com/background-agent?bcId=bc-603fcb17-7241-4fd6-8168-65c182e076a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-603fcb17-7241-4fd6-8168-65c182e076a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

