### PR TITLE
Fix tab bar immediate navigation

### DIFF
--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -122,7 +122,7 @@ const TabsLayout = () => {
             screenOptions={{
               tabBarShowLabel: false,
               lazy: false,
-              animationEnabled: true,
+              animationEnabled: false,
               swipeEnabled: false,
               tabBarStyle: { elevation: 0 },
               sceneContainerStyle: {
@@ -132,6 +132,7 @@ const TabsLayout = () => {
                 overflow: "hidden",
               },
             }}
+            initialLayout={{ width: screenWidth }}
             tabBar={(props) => (
               <Animated.View style={animatedTabBarStyle}>
                 <View
@@ -142,73 +143,63 @@ const TabsLayout = () => {
                   }}
                 >
                   <View className="flex-row justify-around items-center h-full">
-                    <TouchableOpacity
-                      className="flex-1 items-center justify-center h-full"
-                      onPress={() => props.navigation.navigate("index")}
-                    >
-                      <Home
-                        size={26}
-                        color={
-                          isVideosScreen
-                            ? "white"
-                            : pathname === "/"
-                              ? colors.blue
-                              : "white"
-                        }
-                      />
-                    </TouchableOpacity>
+                    {(() => {
+                      const activeIndex = props.state.index;
+                      const activeRouteName = props.state.routes[activeIndex]?.name;
+                      return (
+                        <>
+                          <TouchableOpacity
+                            className="flex-1 items-center justify-center h-full"
+                            onPress={() => props.navigation.jumpTo("index")}
+                          >
+                            <Home
+                              size={26}
+                              color={activeRouteName === "index" ? colors.blue : "white"}
+                            />
+                          </TouchableOpacity>
 
-                    <TouchableOpacity
-                      className="flex-1 items-center justify-center h-full"
-                      onPress={() => props.navigation.navigate("search")}
-                    >
-                      <PeopleIcon
-                        size={27}
-                        color={
-                          isVideosScreen
-                            ? "white"
-                            : pathname === "/search"
-                              ? colors.blue
-                              : "white"
-                        }
-                      />
-                    </TouchableOpacity>
+                          <TouchableOpacity
+                            className="flex-1 items-center justify-center h-full"
+                            onPress={() => props.navigation.jumpTo("search")}
+                          >
+                            <PeopleIcon
+                              size={27}
+                              color={activeRouteName === "search" ? colors.blue : "white"}
+                            />
+                          </TouchableOpacity>
 
-                    <TouchableOpacity
-                      className="flex-1 items-center justify-center h-full"
-                      onPress={() => props.navigation.navigate("videos")}
-                    >
-                      <TvMinimalPlay
-                        size={26}
-                        color={isVideosScreen ? colors.blue : "white"}
-                      />
-                    </TouchableOpacity>
+                          <TouchableOpacity
+                            className="flex-1 items-center justify-center h-full"
+                            onPress={() => props.navigation.jumpTo("videos")}
+                          >
+                            <TvMinimalPlay
+                              size={26}
+                              color={activeRouteName === "videos" ? colors.blue : "white"}
+                            />
+                          </TouchableOpacity>
 
-                    <TouchableOpacity
-                      className="flex-1 items-center justify-center h-full"
-                      onPress={() => props.navigation.navigate("notifications")}
-                    >
-                      <Bell
-                        size={26}
-                        color={
-                          isVideosScreen
-                            ? "white"
-                            : pathname === "/notifications"
-                              ? colors.blue
-                              : "white"
-                        }
-                      />
-                    </TouchableOpacity>
+                          <TouchableOpacity
+                            className="flex-1 items-center justify-center h-full"
+                            onPress={() => props.navigation.jumpTo("notifications")}
+                          >
+                            <Bell
+                              size={26}
+                              color={activeRouteName === "notifications" ? colors.blue : "white"}
+                            />
+                          </TouchableOpacity>
 
-                    <TouchableOpacity
-                      className="flex-1 items-center justify-center h-full"
-                      onPress={() => props.navigation.navigate("profile")}
-                    >
-                      <Menu
-                        size={26}
-                        color={pathname === "/profile" ? colors.blue : "white"}
-                      />
-                    </TouchableOpacity>
+                          <TouchableOpacity
+                            className="flex-1 items-center justify-center h-full"
+                            onPress={() => props.navigation.jumpTo("profile")}
+                          >
+                            <Menu
+                              size={26}
+                              color={activeRouteName === "profile" ? colors.blue : "white"}
+                            />
+                          </TouchableOpacity>
+                        </>
+                      );
+                    })()}
                   </View>
 
                   {/* ✅ INSTANT INDICATOR - NO ANIMATION DELAYS */}
@@ -216,17 +207,22 @@ const TabsLayout = () => {
                     className="absolute bottom-0 left-0 right-0 h-0.5"
                     style={{ backgroundColor: colors.border }}
                   >
-                    <View
-                      className="h-full bg-blue-500"
-                      style={{
-                        width: `${100 / NUM_TABS}%`,
-                        transform: [
-                          {
-                            translateX: getIndicatorPosition(),
-                          },
-                        ],
-                      }}
-                    />
+                    {(() => {
+                      const activeIndex = props.state.index;
+                      return (
+                        <View
+                          className="h-full bg-blue-500"
+                          style={{
+                            width: `${100 / NUM_TABS}%`,
+                            transform: [
+                              {
+                                translateX: activeIndex * (screenWidth / NUM_TABS),
+                              },
+                            ],
+                          }}
+                        />
+                      );
+                    })()}
                   </View>
                 </View>
               </Animated.View>


### PR DESCRIPTION
Make tab switching instantaneous by disabling animations and using `jumpTo` for immediate navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-88f84bb4-917f-4523-88bd-eed074ea12b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-88f84bb4-917f-4523-88bd-eed074ea12b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

