### PR TITLE
Handle video aspect ratios with letterboxing

### DIFF
--- a/mobile/app/(tabs)/videos.tsx
+++ b/mobile/app/(tabs)/videos.tsx
@@ -160,6 +160,11 @@ const VideoItem = ({
     return Math.min(maxVideoHeight, allowedHeight);
   }, [computedHeight, bottomSafeOffset, commentBarHeight]);
 
+  const dynamicResizeMode = useMemo(() => {
+    if (!naturalWidth || !naturalHeight) return ResizeMode.COVER;
+    return naturalHeight >= naturalWidth ? ResizeMode.COVER : ResizeMode.CONTAIN;
+  }, [naturalWidth, naturalHeight]);
+
   const handleLongPress = () => {
     likeButtonRef.current?.measure((_x, _y, _w, _h, pageX, pageY) => {
       setAnchorMeasurements({ pageX, pageY });
@@ -184,9 +189,9 @@ const VideoItem = ({
       >
         <Video
           ref={videoRef}
-          style={{ width: "100%", height: "100%" }} // fills the item container
+          style={{ width: "100%", height: "100%", backgroundColor: "black" }} // fills the item container
           source={{ uri: item.video! }}
-          resizeMode={ResizeMode.COVER}
+          resizeMode={dynamicResizeMode}
           isLooping
           shouldPlay={false}
           onLoad={(status) => {


### PR DESCRIPTION
Update video display on reels page to letterbox landscape videos and keep portrait videos full-screen.

---
<a href="https://cursor.com/background-agent?bcId=bc-d10707f5-f950-4828-8237-f91953a47f1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d10707f5-f950-4828-8237-f91953a47f1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

