### PR TITLE
Change bottom nav bar background color

### DIFF
--- a/mobile/app/chat/[channelId].tsx
+++ b/mobile/app/chat/[channelId].tsx
@@ -3,7 +3,7 @@ import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useStreamChat } from "@/context/StreamChatContext";
 import { Ionicons } from "@expo/vector-icons";
 import { router, useLocalSearchParams } from "expo-router";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -26,6 +26,8 @@ import { StatusBar } from "expo-status-bar";
 import { useTheme } from "@/context/ThemeContext";
 import { LightThemeColors, DarkThemeColors } from "@/constants/Colors"; // Import both theme colors
 import * as SystemUI from "expo-system-ui";
+import * as NavigationBar from "expo-navigation-bar";
+import { useFocusEffect } from "@react-navigation/native";
 import ChatHeader from "@/components/chat/ChatHeader";
 import MessageBubble from "@/components/chat/MessageBubble";
 import MessageInput from "@/components/chat/MessageInput";
@@ -147,6 +149,21 @@ export default function ChatScreen() {
       keyboardDidHideListener?.remove();
     };
   }, [systemUIHeight]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (Platform.OS === "android") {
+        NavigationBar.setBackgroundColorAsync("#ffffff");
+        NavigationBar.setButtonStyleAsync("dark");
+      }
+      return () => {
+        if (Platform.OS === "android") {
+          NavigationBar.setBackgroundColorAsync(isDarkMode ? "#000000" : "#ffffff");
+          NavigationBar.setButtonStyleAsync(isDarkMode ? "light" : "dark");
+        }
+      };
+    }, [isDarkMode])
+  );
 
   const sendMessage = async () => {
     if (!channel || (!newMessage.trim() && !selectedMedia) || sending) return;

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -42,6 +42,7 @@
         "expo-image-picker": "~16.1.4",
         "expo-linear-gradient": "~14.1.5",
         "expo-linking": "~7.1.7",
+        "expo-navigation-bar": "~3.0.6",
         "expo-router": "~5.1.5",
         "expo-secure-store": "~14.2.4",
         "expo-splash-screen": "~0.30.10",
@@ -10190,6 +10191,25 @@
       "dependencies": {
         "invariant": "^2.2.4"
       }
+    },
+    "node_modules/expo-navigation-bar": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/expo-navigation-bar/-/expo-navigation-bar-3.0.7.tgz",
+      "integrity": "sha512-KCNHyZ58zoN4xdy7D1lUdJvveCYNVQHGSX4M6xO/SZypvI6GZbLzKSN6Lx4GDGEFxG6Kb+EAckZl48tSiNeGYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-native/normalize-colors": "0.74.85",
+        "debug": "^4.3.2"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-navigation-bar/node_modules/@react-native/normalize-colors": {
+      "version": "0.74.85",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.74.85.tgz",
+      "integrity": "sha512-pcE4i0X7y3hsAE0SpIl7t6dUc0B0NZLd1yv7ssm4FrLhWG+CGyIq4eFDXpmPU1XHmL5PPySxTAjEMiwv6tAmOw==",
+      "license": "MIT"
     },
     "node_modules/expo-router": {
       "version": "5.1.5",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -44,6 +44,7 @@
     "expo-image-picker": "~16.1.4",
     "expo-linear-gradient": "~14.1.5",
     "expo-linking": "~7.1.7",
+    "expo-navigation-bar": "~3.0.6",
     "expo-router": "~5.1.5",
     "expo-secure-store": "~14.2.4",
     "expo-splash-screen": "~0.30.10",


### PR DESCRIPTION
Set Android navigation bar background to white on chat screen focus using `expo-navigation-bar` for testing.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a06ee40-9e73-4e92-83a6-a2bc7e96f29d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5a06ee40-9e73-4e92-83a6-a2bc7e96f29d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

