### PR TITLE
Fix expo navigation bar background color in chat

### DIFF
--- a/mobile/app/chat/[channelId].tsx
+++ b/mobile/app/chat/[channelId].tsx
@@ -153,11 +153,23 @@ export default function ChatScreen() {
   useFocusEffect(
     useCallback(() => {
       if (Platform.OS === "android") {
+        // Ensure nav bar is not edge-to-edge while chatting, so background color is applied
+        try {
+          // Set position relative (content above nav bar) and prefer insets for swipe
+          // Some devices ignore behavior; set both to maximize compatibility
+          NavigationBar.setPositionAsync("relative");
+          NavigationBar.setBehaviorAsync("inset-swipe");
+        } catch {}
         NavigationBar.setBackgroundColorAsync("#ffffff");
         NavigationBar.setButtonStyleAsync("dark");
       }
       return () => {
         if (Platform.OS === "android") {
+          try {
+            // Restore edge-to-edge preference used app-wide
+            NavigationBar.setPositionAsync("absolute");
+            NavigationBar.setBehaviorAsync("overlay-swipe");
+          } catch {}
           NavigationBar.setBackgroundColorAsync(isDarkMode ? "#000000" : "#ffffff");
           NavigationBar.setButtonStyleAsync(isDarkMode ? "light" : "dark");
         }

--- a/mobile/config.json
+++ b/mobile/config.json
@@ -19,6 +19,10 @@
       "edgeToEdgeEnabled": true,
       "package": "com.ejjays.mobile"
     },
+    "androidNavigationBar": {
+      "backgroundColor": "#ffffff",
+      "barStyle": "dark-content"
+    },
     "web": {
       "bundler": "metro",
       "output": "static",


### PR DESCRIPTION
Ensure the Android navigation bar is opaque white in the chat screen and set a default app-wide white background.

The navigation bar was remaining transparent on Android devices due to edge-to-edge settings overriding background color attempts. This fix explicitly sets the navigation bar to a 'relative' position and 'inset-swipe' behavior while in the chat screen to ensure the background color is applied.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6989661-8d6e-4598-8d44-191efeb7709f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a6989661-8d6e-4598-8d44-191efeb7709f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

